### PR TITLE
Add deprecated container warning to expected errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
 const expectedErrors: RegExp[] = [
   /(WARNING|ERROR)\(sdk\/java\/api.*/,
   /ERROR #98124  WEBPACK/,
+  /WARNING.*: Directive "container" has been deprecated/,
   /Title (overline|underline) too (short|long)/, // Seriously?!
 ];
 


### PR DESCRIPTION
The new [Swift SDK landing page](https://github.com/mongodb/docs-realm/pull/2181), which we're planning to roll out across all the SDKs, uses the deprecated "container" directive to tweak the styling. I'd like to add that to the expected errors so the presence of this warning does not result in a [Snooty Autobuilder check failure](https://github.com/mongodb/docs-realm/actions/runs/3161628379/jobs/5147425160). This should fix these lines (and many more, soon) that would appear in the build logs:

```
Build completed at 2022-09-30T21:02:15.183Z
Encountered the following unexpected errors:
WARNING(sdk/swift.txt:174ish): Directive "container" has been deprecated
WARNING(sdk/swift.txt:192ish): Directive "container" has been deprecated
```