### PR TITLE
Add an expected warning for directive cssclass deprecation

### DIFF
--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -3,6 +3,7 @@ module.exports = {
     /(WARNING|ERROR)\(sdk\/java\/api.*/,
     /ERROR #98124  WEBPACK/,
     /WARNING.*: Directive "container" has been deprecated/,
+    /WARNING.*: Directive "cssclass" has been deprecated/,
     /Title (overline|underline) too (short|long)/,
   ],
   timeoutMs: 7 * 60 * 1000,


### PR DESCRIPTION
Alas, new warning about a deprecated `cssclass` in docs-realm: https://github.com/mongodb/docs-realm/actions/runs/4208050026/jobs/7303613789

From a handful of pages, this warning: `WARNING(sdk/react-native/bootstrap-with-expo.txt:75ish): Directive "cssclass" has been deprecated`